### PR TITLE
[Fix] Mitigate high CPU when connect/disconnect an MCP server

### DIFF
--- a/backend/chainlit/mcp.py
+++ b/backend/chainlit/mcp.py
@@ -10,6 +10,7 @@ class StdioMcpConnection(BaseModel):
     name: str
     command: str
     args: list[str]
+    env: dict[str, str]
     clientType: Literal["stdio"] = "stdio"
 
 

--- a/backend/chainlit/server.py
+++ b/backend/chainlit/server.py
@@ -1275,7 +1275,7 @@ async def _setup_mcp_session(
     ready_event = asyncio.Event()
 
     async def _call() -> None:
-        from mcp import ClientSession
+        from mcp.client.session import ClientSession
         from mcp.client.sse import sse_client
         from mcp.client.stdio import (
             StdioServerParameters,

--- a/backend/chainlit/session.py
+++ b/backend/chainlit/session.py
@@ -203,7 +203,7 @@ class McpSession:
     def __init__(
         self,
         name: str,
-        session: ClientSession,
+        session: "ClientSession",
         task: asyncio.Task,
         stop_event: asyncio.Event,
     ):

--- a/backend/chainlit/socket.py
+++ b/backend/chainlit/socket.py
@@ -331,16 +331,20 @@ async def window_message(sid, data):
 
 
 @sio.on("audio_start")  # pyright: ignore [reportOptionalCall]
-async def audio_start(sid):
+async def audio_start(sid: str):
     """Handle audio init."""
     session = WebsocketSession.require(sid)
 
     context = init_ws_context(session)
     config: ChainlitConfig = session.get_config()
 
-    if config.features.audio and config.features.audio.enabled:
+    if (
+        config.features.audio
+        and config.features.audio.enabled
+        and config.code.on_audio_start
+    ):
         connected = bool(await config.code.on_audio_start())
-        connection_state = "on" if connected else "off"
+        connection_state: Literal["on", "off"] = "on" if connected else "off"
         await context.emitter.update_audio_connection(connection_state)
 
 
@@ -362,7 +366,7 @@ async def audio_chunk(sid, payload: InputAudioChunkPayload):
 
 
 @sio.on("audio_end")
-async def audio_end(sid):
+async def audio_end(sid: str):
     """Handle the end of the audio stream."""
     session = WebsocketSession.require(sid)
 
@@ -376,7 +380,11 @@ async def audio_end(sid):
 
         config: ChainlitConfig = session.get_config()
 
-        if config.features.audio and config.features.audio.enabled:
+        if (
+            config.features.audio
+            and config.features.audio.enabled
+            and config.code.on_audio_end
+        ):
             await config.code.on_audio_end()
 
     except asyncio.CancelledError:


### PR DESCRIPTION
## Summary
This is a short-term mitigation for AnyIO complaining about different enter/exit task context. See detailed issues and example fixes in:

<details>
<summary>py-spy top result</summary>

Majority of CPU time spent on [_deliver_cancellation](https://github.com/agronholm/anyio/blob/c2f7289353f1533c60f5d0fdd2904f804cc09650/src/anyio/_backends/_asyncio.py#L554) method.

```sh
Total Samples 2700
GIL: 71.00%, Active: 71.00%, Threads: 3

  %Own   %Total  OwnTime  TotalTime  Function (filename)                                                                                                                                                      
 22.00%  41.00%    5.27s     9.06s   _deliver_cancellation (anyio/_backends/_asyncio.py)
 10.00%  70.00%    1.38s    11.83s   _run_once (nest_asyncio.py)
 18.00%  59.00%    1.37s    10.43s   _run (asyncio/events.py)
  6.00%  12.00%    1.06s     1.98s   _call_soon (asyncio/base_events.py)
  6.00%   6.00%   0.850s    0.920s   __init__ (asyncio/events.py)
  1.00%   4.00%   0.720s     1.29s   cancel (asyncio/tasks.py)
  1.00%  71.00%   0.560s    12.59s   run_until_complete (nest_asyncio.py)
  2.00%   2.00%   0.440s    0.440s   done (asyncio/futures.py)
  2.00%  15.00%   0.410s     2.50s   call_soon (asyncio/base_events.py)
  1.00%   1.00%   0.330s    0.330s   _log_traceback (asyncio/futures.py)
  1.00%   1.00%   0.110s    0.110s   _check_closed (asyncio/base_events.py)
  0.00%   0.00%   0.070s    0.070s   get_debug (asyncio/base_events.py)
  1.00%   1.00%   0.020s    0.020s   time (asyncio/base_events.py)
  0.00%  71.00%   0.000s    12.59s   run (nest_asyncio.py)
  0.00%  71.00%   0.000s    12.59s   <module> (chainlit)
  0.00%  71.00%   0.000s    12.59s   main (click/core.py)
  0.00%  71.00%   0.000s    12.59s   __call__ (click/core.py)
  0.00%  71.00%   0.000s    12.59s   invoke (click/core.py)
  0.00%  71.00%   0.000s    12.59s   chainlit_run (chainlit/cli/__init__.py)
  0.00%  71.00%   0.000s    12.59s   run_chainlit (chainlit/cli/__init__.py)
```
</details>

<details>
<summary>local test run</summary>

```py
 In [47]: async def test():
    ...:         exit_stack = AsyncExitStack()
    ...:         transport = await exit_stack.enter_async_context(streamablehttp_client(url
       ⋮ ='http://app-mcp-server.local:80/mcp', headers={'Content-Type': 'application/json'
       ⋮ }))
    ...:         read, write = transport[:2]
    ...:         mcp_session = await exit_stack.enter_async_context(ClientSession(read_stre
       ⋮ am=read, write_stream=write, sampling_callback=None))
    ...:         await mcp_session.initialize()
    ...:         tool_list = await mcp_session.list_tools()
    ...:         return mcp_session, exit_stack, tool_list
    ...: 

In [48]: await test()


In [49]: mcp_session, exit_stack, tools = _


In [53]: await exit_stack.aclose()
  + Exception Group Traceback (most recent call last):
  |   File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 772, in __aexit__
  |     raise BaseExceptionGroup(
  | ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/mcp/client/streamable_http.py", line 502, in streamablehttp_client
    |     yield (
    |   File "/usr/lib/python3.12/contextlib.py", line 737, in __aexit__
    |     cb_suppress = await cb(*exc_details)
    |                   ^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/mcp/shared/session.py", line 218, in __aexit__
    |     return await self._task_group.__aexit__(exc_type, exc_val, exc_tb)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 783, in __aexit__
    |     return self.cancel_scope.__exit__(exc_type, exc_val, exc_tb)
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 457, in __exit__
    |     raise RuntimeError(
    | RuntimeError: Attempted to exit cancel scope in a different task than it was entered in
    +------------------------------------

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/IPython/core/interactiveshell.py", line 3697, in run_code
    await eval(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-53-ea1e1ba3473b>", line 1, in <module>
    await exit_stack.aclose()
  File "/usr/lib/python3.12/contextlib.py", line 696, in aclose
    await self.__aexit__(None, None, None)
  File "/usr/lib/python3.12/contextlib.py", line 754, in __aexit__
    raise exc_details[1]
  File "/usr/lib/python3.12/contextlib.py", line 737, in __aexit__
    cb_suppress = await cb(*exc_details)
                  ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/contextlib.py", line 231, in __aexit__
    await self.gen.athrow(value)
  File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/mcp/client/streamable_http.py", line 478, in streamablehttp_client
    async with anyio.create_task_group() as tg:
  File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 778, in __aexit__
    if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/booktrail/src/dev/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 457, in __exit__
    raise RuntimeError(
RuntimeError: Attempted to exit cancel scope in a different task than it was entered in

In [54]: 
``` 
</details>

## After this fix
CPU no longer shoots to 100% after connect & reconnect an MCP server. Following log lines confirm this.

```sh
2025-10-01 19:23:57 - Sending stop event to app
2025-10-01 19:23:57 - Waiting for task app to finish
2025-10-01 19:23:57 - Closing MCP session app
2025-10-01 19:23:57 - HTTP Request: DELETE http://app-mcp-server.local/mcp "HTTP/1.1 200 OK"
2025-10-01 19:23:57 - MCP session app closed
2025-10-01 19:23:57 - Task app finished
```